### PR TITLE
fix bug occurring with even number of accounts when inserting dummy

### DIFF
--- a/lib/bsolp.js
+++ b/lib/bsolp.js
@@ -18,7 +18,7 @@ function combine_nodes (left_node, right_node) {
 // add fake nodes with 0 balance? maybe all right leaf node should be a dummy user?
 function generate_private_tree (accounts) {
   // Make sure number of nodes is odd so we don't have a lonely leaf
-  if (accounts.length % 2 === 0) accounts.push({ user: 'dummy', amount: 0 });
+  if (accounts.length % 2 === 0) accounts.push({ user: 'dummy', balance: 0 });
 
   // Generate initial hash / value for leaf nodes
   accounts.forEach(function (account) {


### PR DESCRIPTION
fix bug occurring with even number of accounts when inserting dummy 

(rename "amount" -> "balance")
