### PR TITLE
Leaf node hashes: include balance, use separators.

### DIFF
--- a/lib/blproof.js
+++ b/lib/blproof.js
@@ -38,9 +38,8 @@ function generate_complete_tree (accounts) {
   // Generate initial hash / value for leaf nodes
   accounts.forEach(function (account) {
     account.value = account.balance;
-    account.user = account.user; //sha256(account.user);
     account.nonce = nonce();
-    account.hash = sha256(account.user + '' + account.nonce); //sha256(account.user);
+    account.hash = sha256(account.user + '|' + account.balance + '|' + account.nonce);
     delete account.balance;
   });
 


### PR DESCRIPTION
Without the balance change (or similar), evil exchanges can cheat; see
https://iwilcox.me.uk/2014/proving-bitcoin-reserves#pairing.

Separators are mostly pedantic, depriving an evil exchange of only a very
tiny degree of freedom.  Say you have:
- real user "olal", to whom you give nonce "onde1234"
- real user "olalonde", to whom you give nonce "1234"
- dummy user "olalon", to whom you give nonce "de1234"

Now you can make any two of these nodes siblings and tell a real user
that a node represents them when really it represents someone else
with a or nobody real at all.

This is less of a problem if balance is included, but separators still
stop confusion between pairs of users like:
- "olalonde99" with balance "9.0"
- "olalonde9" with balance "99.0"
