### PR TITLE
 Describe serialisation format very fully/formally

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,17 @@ A JSON object:
 `hash` and `sum` are calculated as [described above](#hashing-internal-nodes);
 both are JSON strings.  `hash` is encoded as a 64-digit hexadecimal string
 with lowercase letters.  The contents of string `sum` **should** be identical
-to the hashed representation, but equivalents with fewer decimal places or no
-fractional part that still match the regex are allowed.
+to the [representation used in hashing](#hashing-internal-nodes), but
+equivalents (which add a fractional part with zeros in all decimal places, or
+which add trailing zeros to an existing fractional part) that still match the
+regex are allowed.
 
 Example:
 
 ```javascript
 { 
   "root": {
-    "sum": "37618.00000000",
+    "sum": "37618",
     "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   }
 }
@@ -288,9 +290,10 @@ node has the following format:
 name/value pairs:
 
  * `sum` (JSON string): as [described above](#hashing-internal-nodes).  The
-   contents **should** be identical to the hashed representation, but
-   equivalents with fewer decimal places or no fractional part that still match
-   the regex are allowed.
+   contents **should** be identical to the [representation used in
+   hashing](#hashing-internal-nodes), but equivalents (which add a fractional
+   part with zeros in all decimal places, or which add trailing zeros to an
+   existing fractional part) that still match the regex are allowed.
      * Immediate children of nodes on the root path **must** have this key set.
      * Other nodes **should not** have this key set.
  * `hash` (JSON string): generated as [described
@@ -308,6 +311,29 @@ name/value pairs:
      * The node belonging to the user this partial tree was generated for **must**
        have this key set.
      * All other nodes **must not** have this key set.
+
+If redundant keys are omitted as suggested, the `"data": <node_data>` key/value
+pair will have an empty object (`{}`) for `<node_data>`, in which case the
+key/value pair **should** be omitted.
+
+Example leaf node's `<node_data>`:
+
+```javascript
+{
+  "user": "frank@example.com",
+  "sum": "3.1415",
+  "nonce": "e3b0c44298fc1c149afbf4c8996fb924",
+}
+```
+
+Example `<node_data>` for an immediate child of a node on the root path:
+
+```javascript
+{
+  "sum": "71.31",
+  "hash": "81dbc2416e7ead6a4ac1db605c56e293119a7ed65f3c80fdf1abbceeef22ac15"
+}
+```
 
 ### Account lists
 


### PR DESCRIPTION
As promised, this patch to README.md covers the key parts in unambiguous gory glory.

Specifically, the changes are:
- SHA256 hashes are now hex-encoded instead of base64-encoded (you'll need to fix the specific ones used in your CLI examples; I just blindly put some arbitrary SHA256s in)
- nonces now have explicit advice on length and specified hex encoding
- balances are in strings, ensuring that code handling them gets to make explicit decisions to avoid rounding issues (as opposed to leaving it to the JSON library!)
- there are pointers to the "proper money handling" code snippets on the Bitcoin wiki in the right place
- the form that inputs to SHA256 take is explicit/unambiguous/predictable, and worked examples are given
  - especially for Bitcoin (otherwise verifiers would have to try hashing 1.23, 1.230, 1.2300 etc until they found a match)
- there's convention on producing accounts trees deterministically, to ensure predictable root hashes
- the advice to omit data to encourage its regeneration for verification is repeated in the partial tree section
- "value" is now "sum" everywhere
- "interior" is now "internal" everywhere as it seems the more common term according to a GoogleFight

Doubts:
- maybe we should make nonces _more_ free but not totally free; e.g. disallow troublesome things like embedded '|' and control characters, but otherwise not constrain them (to hexadecimal, which is what I've said) since nothing relies on them
