### PR TITLE
Added timestamp and currency to root serialization specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ regex are allowed.
 user balances were retrieved.
 
 [currency code]: http://en.wikipedia.org/wiki/Currency_codes
-[unix timestamp]: 
+[unix timestamp]: http://en.wikipedia.org/wiki/Unix_timestamp
 
 Example:
 


### PR DESCRIPTION
I've added a timestamp and a currency property to the root serialization specification. Here's the rationale behind the 2 properties:

`timestamp`: since a liability proof may have been computed a few hours/days in the past, a user/verifier needs to know at which point it was computed in order to check if the balance shown in the partial tree matches the amount he had at that time on the exchange. The timestamp is a unix timestamp represented as a JSON string (it might be a good idea to use block height instead).

`currency`: since a site might hold deposits in multiple currencies, this will let users know which one of their deposits the balance in the partial tree represents. It is a 3 letter currency code represented as a JSON string.
