### PR TITLE
Use '|' to separate in nodecombiner

### DIFF
--- a/lib/blproof.js
+++ b/lib/blproof.js
@@ -40,7 +40,7 @@ function clone (obj) {
 function combine_nodes (left_node, right_node) {
   var n = {};
   n.sum = big(left_node.sum).plus(right_node.sum);
-  n.hash = sha256(n.sum + '' + left_node.hash + '' + right_node.hash);
+  n.hash = sha256(n.sum + '|' + left_node.hash + '|' + right_node.hash);
   return n;
 }
 


### PR DESCRIPTION
To match https://github.com/olalonde/proof-of-liabilities#hashing-internal-nodes
